### PR TITLE
always decode result from check_output

### DIFF
--- a/version.py
+++ b/version.py
@@ -7,7 +7,7 @@ command = 'git describe --tags --long --dirty'
 
 def validate_version_format(dist, attr, value):
     try:
-        version = check_output(command.split()).strip()
+        version = check_output(command.split()).decode('utf-8').strip()
     except:
         version = get_distribution(dist.get_name()).version
     else:


### PR DESCRIPTION
in python 3.4 the result is of type `byte`, so we must explicitly
convert this. it seems to work well enough in python2.7 but short of
setting up mock tests for check_output i couldn't come up with a test
for this.
